### PR TITLE
make the version importable

### DIFF
--- a/dash_auth/__init__.py
+++ b/dash_auth/__init__.py
@@ -1,3 +1,4 @@
 from __future__ import absolute_import
 from .plotly_auth import PlotlyAuth  # noqa: F401
 from .basic_auth import BasicAuth  # noqa: F401
+from .version import __version__  # noqa: F401


### PR DESCRIPTION
so that you can do `print(dash_auth.__version__)`

cc @cldougl 