### PR TITLE
Print exception info when request fails

### DIFF
--- a/dash_auth/api_requests.py
+++ b/dash_auth/api_requests.py
@@ -139,9 +139,9 @@ def _create_method(method_name):
             debug_requests_off()
             try:
                 return request_with_retry(url, **kwargs)
-            except Exception as e:
+            except BaseException:
                 # request-level errors include ConnectionError
-                print(e)
+                print(sys.exc_info())
 
                 # do the request one last time with logs
                 debug_requests_on(url)


### PR DESCRIPTION
The previous version crashed when handling the exception, meaning that nothing was printed at that point.

This is major bug 2 (out of 2) from the BNY Mellon call yesterday.

* [x] Tested in Dash On Premise.
* [x] @chriddyp Can `dash-auth` be run locally? If so I'll test that.

@chriddyp Please review.