### PR TITLE
Handle >1 OAuth app

### DIFF
--- a/dash_auth/plotly_auth.py
+++ b/dash_auth/plotly_auth.py
@@ -206,11 +206,7 @@ def create_or_overwrite_oauth_app(app_url, name):
         print(res.content)
         raise e
     apps = res.json()
-    if len(apps) > 1:
-        raise Exception(
-            'There are more than one oauth apps with the name {}.'.format(name)
-        )
-    elif len(apps) == 1:
+    if apps:
         oauth_app_id = apps[0]['id']
         res = api_requests.patch(
             '/v2/oauth-apps/{}'.format(oauth_app_id),


### PR DESCRIPTION
This can happen due to a race condition, and is harmless. Update the first app in the list returned by streambed, and use its client ID. (Since we don't use the client ID of any additional apps, they can be ignored.)

Fixes https://github.com/plotly/streambed/issues/10881

@chriddyp Please review.