### PR TITLE
Logout button

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,8 @@ setup(
         'flask-seasurf',
         'plotly',
         'dash>=0.18.3',
+        'dash_html_components',
+        'dash_core_components',
         'retrying',
         'itsdangerous'
     ],

--- a/tests/test_plotlyauth.py
+++ b/tests/test_plotlyauth.py
@@ -23,7 +23,7 @@ endpoints = {
         'get': [
             '/_dash-layout', '/_dash-routes', '/_dash-dependencies',
             '/_dash-component-suites/dash_html_components/bundle.js',
-            '/static/',
+            '/static/', '/assets/'
         ],
         'post': ['/_dash-update-component']
     },


### PR DESCRIPTION
Add a `logout` and `create_logout_button` methods to PlotlyAuth.

- `logout` 
    - Must be called from a callback, takes no arguments.
    - Invalidate the plotly_oauth_token.
    - Clear the auth cookies.
- `create_logout_button` 
    - Returns a logout button component to use in a dash layout.
    - Call `logout` once clicked then redirect.
    - Options:
        - `label`: The text (or children component) on the button `(default='Logout')`.
        - `redirect_to`: Redirect the browser to this link when the button is clicked `(default='https://plot.ly)`.
    - Also takes props keywords from `html.Button` like `style`, `className`, etc.

Example:

```python
import dash
import dash_auth

import dash_html_components as html

app = dash.Dash(__name__)

auth = dash_auth.PlotlyAuth(
    app, 'logout', 'public',
    'http://localhost:8050/')

btn_style = {
    'backgroundColor': 'red',
    'padding': '16px',
    'borderRadius': '8px',
    'border': 'none'
}

app.layout = html.Div([
    html.Div('content', id='content'),
    auth.create_logout_button(
        style=btn_style,
        label='Sign out',
        redirect_to='https://www.google.com')
])

if __name__ == '__main__':
    app.run_server()
```
