### PR TITLE
Remove username cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,11 @@ executors:
   python-27:
     docker:
         - image: circleci/python:2.7-stretch-browsers
-    resource_class: large
+    resource_class: xlarge
   python-36:
     docker:
         - image: circleci/python:3.6-stretch-browsers
-    resource_class: large
+    resource_class: xlarge
 
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
             flake8 dash_auth setup.py
 
       - run:
-          name: Test with pytest
+          name: Run tests
           command: |
             . venv/bin/activate
             python -m unittest -v tests.test_basic_auth_integration

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
 
 
 jobs:
-  "python-2.7": &test-template
+  python-2.7: &test-template
     executor: python-27
 
     steps:
@@ -53,7 +53,7 @@ jobs:
             python -m unittest -v tests.test_api_requests
             python -m unittest -v tests.test_plotlyauth
 
-  "python-3.6":
+  python-3.6:
     <<: *test-template
     executor: python-36
 
@@ -61,5 +61,5 @@ workflows:
   version: 2
   build:
     jobs:
-      - "python-2.7"
-      - "python-3.6"
+      - python-2.7
+      - python-3.6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,19 @@
-version: 2
+version: 2.1
+
+executors:
+  python-27:
+    docker:
+        - image: circleci/python:2.7-stretch-browsers
+    resource_class: large
+  python-36:
+    docker:
+        - image: circleci/python:3.6-stretch-browsers
+    resource_class: large
+
 
 jobs:
   "python-2.7": &test-template
-    docker:
-      - image: circleci/python:2.7-stretch-browsers
+    executor: python-27
 
     steps:
       - checkout
@@ -45,8 +55,7 @@ jobs:
 
   "python-3.6":
     <<: *test-template
-    docker:
-      - image: circleci/python:3.6-stretch-browsers
+    executor: python-36
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
 
 
 jobs:
-  python-2.7: &test-template
+  python-27: &test-template
     executor: python-27
 
     steps:
@@ -53,7 +53,7 @@ jobs:
             python -m unittest -v tests.test_api_requests
             python -m unittest -v tests.test_plotlyauth
 
-  python-3.6:
+  python-36:
     <<: *test-template
     executor: python-36
 
@@ -61,5 +61,5 @@ workflows:
   version: 2
   build:
     jobs:
-      - python-2.7
-      - python-3.6
+      - python-27
+      - python-36

--- a/dash_auth/oauth.py
+++ b/dash_auth/oauth.py
@@ -47,7 +47,6 @@ class OAuthBase(Auth):
         self._app = app
         self._app_url = app_url
         self._oauth_client_id = client_id
-        self._username_cache = {}
 
         if secret_key is None and app.server.secret_key is None:
             raise Exception(dedent('''
@@ -331,10 +330,8 @@ class OAuthBase(Auth):
         :return: The stored username if any.
         :rtype: str
         """
-        cached = self._username_cache.get(flask.request.remote_addr)
-        if cached:
-            return cached
         username = flask.request.cookies.get(self.USERNAME_COOKIE)
+
         if username:
             max_age = None
             if validate_max_age:
@@ -368,7 +365,6 @@ class OAuthBase(Auth):
         :type response: flask.Response
         :return:
         """
-        self._username_cache[flask.request.remote_addr] = name
 
         if not response:
             @flask.after_this_request
@@ -378,7 +374,6 @@ class OAuthBase(Auth):
                     self.USERNAME_COOKIE,
                     self._signer.sign(name),
                     max_age=self.config['user_cookies_expiry'])
-                del self._username_cache[flask.request.remote_addr]
                 return rep
         else:
             self.set_cookie(

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,3 +11,4 @@ requests[security]
 ipdb
 flake8
 retrying
+flaky

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,4 +11,3 @@ requests[security]
 ipdb
 flake8
 retrying
-chromedriver

--- a/tests/IntegrationTests.py
+++ b/tests/IntegrationTests.py
@@ -38,7 +38,7 @@ class IntegrationTests(unittest.TestCase):
     def setUpClass(cls):
         super(IntegrationTests, cls).setUpClass()
         options = webdriver.ChromeOptions()
-        options.headless = True
+        # options.headless = True
         options.add_argument('no-sandbox')
         options.add_argument('--disable-dev-shm-usage')
         cls.driver = webdriver.Chrome(options=options)
@@ -51,14 +51,13 @@ class IntegrationTests(unittest.TestCase):
         time.sleep(2)
         self.driver.delete_all_cookies()
         self.driver.refresh()
-        time.sleep(4)
 
         if platform.system() == 'Windows':
             requests.get('http://localhost:8050/stop')
             self.server_thread.join()
         else:
             self.server_process.terminate()
-        time.sleep(3)
+        time.sleep(5)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/IntegrationTests.py
+++ b/tests/IntegrationTests.py
@@ -51,6 +51,7 @@ class IntegrationTests(unittest.TestCase):
         self.driver.refresh()
         time.sleep(4)
         self.server_thread.join()
+        time.sleep(2)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/IntegrationTests.py
+++ b/tests/IntegrationTests.py
@@ -12,7 +12,7 @@ from selenium import webdriver
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
-TIMEOUT = 22
+TIMEOUT = 28
 
 
 class IntegrationTests(unittest.TestCase):
@@ -27,21 +27,29 @@ class IntegrationTests(unittest.TestCase):
                                              assertion_text)
         )
 
+    def wait_for_element_to_be_clickable(self, selector):
+        return WebDriverWait(self.driver, TIMEOUT).until(
+            EC.element_to_be_clickable((By.CSS_SELECTOR, selector))
+        )
+
     @classmethod
     def setUpClass(cls):
         super(IntegrationTests, cls).setUpClass()
 
     def setUp(self):
         options = webdriver.ChromeOptions()
-        # options.headless = True
+        options.headless = True
+        options.add_argument('no-sandbox')
+        options.add_argument('--disable-dev-shm-usage')
         self.driver = webdriver.Chrome(options=options)
 
     def tearDown(self):
         super(IntegrationTests, self).tearDown()
         time.sleep(2)
         requests.get('http://localhost:8050/stop')
-        time.sleep(3)
-        self.driver.quit()
+        self.driver.close()
+        time.sleep(4)
+        self.server_thread.join()
 
     def startServer(self, app, skip_visit=False):
         def run():

--- a/tests/IntegrationTests.py
+++ b/tests/IntegrationTests.py
@@ -35,21 +35,27 @@ class IntegrationTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         super(IntegrationTests, cls).setUpClass()
-
-    def setUp(self):
         options = webdriver.ChromeOptions()
         options.headless = True
         options.add_argument('no-sandbox')
         options.add_argument('--disable-dev-shm-usage')
-        self.driver = webdriver.Chrome(options=options)
+        cls.driver = webdriver.Chrome(options=options)
 
     def tearDown(self):
         super(IntegrationTests, self).tearDown()
         time.sleep(2)
         requests.get('http://localhost:8050/stop')
-        self.driver.close()
+        self.driver.delete_all_cookies()
+        self.driver.get('http://www.plot.ly')
+        self.driver.delete_all_cookies()
+        self.driver.refresh()
         time.sleep(4)
         self.server_thread.join()
+
+    @classmethod
+    def tearDownClass(cls):
+        super(IntegrationTests, cls).tearDownClass()
+        cls.driver.quit()
 
     def startServer(self, app, skip_visit=False):
         def run():

--- a/tests/IntegrationTests.py
+++ b/tests/IntegrationTests.py
@@ -12,7 +12,7 @@ from selenium import webdriver
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
-TIMEOUT = 28
+TIMEOUT = 48
 
 
 class IntegrationTests(unittest.TestCase):
@@ -27,9 +27,9 @@ class IntegrationTests(unittest.TestCase):
                                              assertion_text)
         )
 
-    def wait_for_element_to_be_clickable(self, selector):
+    def wait_for_element_to_be_clickable(self, name):
         return WebDriverWait(self.driver, TIMEOUT).until(
-            EC.element_to_be_clickable((By.CSS_SELECTOR, selector))
+            EC.element_to_be_clickable((By.NAME, name))
         )
 
     @classmethod

--- a/tests/test_plotly_auth_integration.py
+++ b/tests/test_plotly_auth_integration.py
@@ -9,6 +9,7 @@ import time
 import re
 import itertools
 import plotly.plotly as py
+import unittest
 
 from .IntegrationTests import IntegrationTests
 from .utils import assert_clean_console, switch_windows
@@ -80,7 +81,7 @@ class Tests(IntegrationTests):
         time.sleep(3)
 
         # wait for oauth screen
-        self.wait_for_element_by_css_selector('input[name="allow"]').click()
+        self.wait_for_element_to_be_clickable('input[name="allow"]').click()
 
     def private_app_unauthorized(self, url_base_pathname=None,
                                  oauth_urls=None):
@@ -106,7 +107,7 @@ class Tests(IntegrationTests):
             url_base_pathname,
         )
         switch_windows(self.driver)
-        self.driver.implicitly_wait(3)
+        time.sleep(3)
         try:
             el = self.wait_for_element_by_css_selector('#output')
         except:
@@ -275,3 +276,4 @@ class Tests(IntegrationTests):
         btn = self.wait_for_element_by_css_selector('#btn')
         btn.click()
         self.wait_for_text_to_equal('#authorized', 'authorized')
+        time.sleep(2)

--- a/tests/test_plotly_auth_integration.py
+++ b/tests/test_plotly_auth_integration.py
@@ -98,6 +98,7 @@ class Tests(IntegrationTests):
         el = self.wait_for_element_by_css_selector(
             '#dash-auth--authorization__denied')
         self.assertEqual(el.text, 'You are not authorized to view this app')
+        self.driver.close()
         switch_windows(self.driver)
         self.driver.refresh()
         # login screen should still be there
@@ -117,7 +118,7 @@ class Tests(IntegrationTests):
         except:
             print(self.driver.find_element_by_tag_name(
                 'body').get_attribute('innerHTML'))
-        self.assertEqual(el.text, 'initial value')
+        self.wait_for_text_to_equal('#output', 'initial value')
 
     def test_private_app_authorized_index(self):
         self.private_app_authorized('/')

--- a/tests/test_plotly_auth_integration.py
+++ b/tests/test_plotly_auth_integration.py
@@ -1,22 +1,26 @@
 # -*- coding: utf-8 -*-
-from dash.dependencies import Input, Output, State, Event
+from dash.dependencies import Input, Output
 import dash
 import dash_html_components as html
 import dash_core_components as dcc
-from multiprocessing import Value
 import os
 import time
-import re
-import itertools
-import plotly.plotly as py
-import unittest
+
+from flaky import flaky
+from selenium.common.exceptions import TimeoutException
 
 from .IntegrationTests import IntegrationTests
-from .utils import assert_clean_console, switch_windows
+from .utils import switch_windows
 from .users import users
 from dash_auth import plotly_auth
 
 
+def is_timeout(err, *args):
+    print('flaky retrying')
+    return isinstance(err, TimeoutException)
+
+
+@flaky(max_runs=5, rerun_filter=is_timeout)
 class Tests(IntegrationTests):
     def setup_app(self, url_base_pathname=None, skip_visit=False,
                   sharing='private'):
@@ -81,7 +85,7 @@ class Tests(IntegrationTests):
         time.sleep(3)
 
         # wait for oauth screen
-        self.wait_for_element_to_be_clickable('input[name="allow"]').click()
+        self.wait_for_element_to_be_clickable('allow').click()
 
     def private_app_unauthorized(self, url_base_pathname=None,
                                  oauth_urls=None):

--- a/tests/test_plotly_auth_integration.py
+++ b/tests/test_plotly_auth_integration.py
@@ -72,6 +72,7 @@ class Tests(IntegrationTests):
         self.wait_for_element_by_css_selector(
             '#dash-auth--login__button').click()
         switch_windows(self.driver)
+        time.sleep(1)
         self.wait_for_element_by_css_selector(
             '#js-auth-modal-signin-username'
         ).send_keys(username)

--- a/tests/test_plotly_auth_integration.py
+++ b/tests/test_plotly_auth_integration.py
@@ -20,7 +20,6 @@ def is_timeout(err, *args):
     return isinstance(err, TimeoutException)
 
 
-@flaky(max_runs=5, rerun_filter=is_timeout)
 class Tests(IntegrationTests):
     def setup_app(self, url_base_pathname=None, skip_visit=False,
                   sharing='private'):


### PR DESCRIPTION
Remove the username cache, Fixes #70.
Added options to stabilize chrome crashes as the tests are still failing.