### PR TITLE
use bcrypt to hash passwords

### DIFF
--- a/dash_auth/basic_auth.py
+++ b/dash_auth/basic_auth.py
@@ -1,6 +1,7 @@
 from .auth import Auth
 import base64
 import flask
+import bcrypt
 
 
 class BasicAuth(Auth):
@@ -17,7 +18,10 @@ class BasicAuth(Auth):
         username_password = base64.b64decode(header.split('Basic ')[1])
         username_password_utf8 = username_password.decode('utf-8')
         username, password = username_password_utf8.split(':', 1)
-        return self._users.get(username) == password
+        pw_hash = self._users.get(username)
+        if isinstance(pw_hash, str):
+            pw_hash = pw_hash.encode('utf8')
+        return pw_hash and bcrypt.checkpw(password.encode('utf8'), pw_hash)
 
     def login_request(self):
         return flask.Response(

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,3 +9,4 @@ ipdb
 flake8
 retrying
 chromedriver
+bcrypt

--- a/tests/test_basic_auth_integration.py
+++ b/tests/test_basic_auth_integration.py
@@ -3,19 +3,34 @@ import dash
 import dash_html_components as html
 import dash_core_components as dcc
 import requests
+import bcrypt
 
 
 from .IntegrationTests import IntegrationTests
 from dash_auth import basic_auth
 
 
-TEST_USERS = {
+def hash_password(passwd):
+    salt = bcrypt.gensalt()
+    return bcrypt.hashpw(passwd.encode('utf8'), salt)
+
+TEST_USERS_PLAINTEXT = {
     'valid': [
         ['hello', 'world'],
         ['hello2', 'wo:rld']
     ],
     'invalid': [
         ['hello', 'password']
+    ],
+}
+
+TEST_USERS_HASHED = {
+    'valid': [
+        ['hello', hash_password('world')],
+        ['hello2', hash_password('wo:rld')]
+    ],
+    'invalid': [
+        ['hello', hash_password('password')]
     ],
 }
 
@@ -37,7 +52,7 @@ class Tests(IntegrationTests):
 
         basic_auth.BasicAuth(
             app,
-            TEST_USERS['valid']
+            TEST_USERS_HASHED['valid']
         )
 
         self.startServer(app, skip_visit=True)
@@ -48,7 +63,7 @@ class Tests(IntegrationTests):
         )
 
         # Test login for each user:
-        for user, password in TEST_USERS['valid']:
+        for user, password in TEST_USERS_PLAINTEXT['valid']:
             # login using the URL instead of the alert popup
             # selenium has no way of accessing the alert popup
             self.driver.get(

--- a/usage_basic_auth.py
+++ b/usage_basic_auth.py
@@ -4,9 +4,15 @@ import dash_auth
 import dash_html_components as html
 import dash_core_components as dcc
 
+import bcrypt
+
+def hash_password(passwd):
+    salt = bcrypt.gensalt()
+    return bcrypt.hashpw(passwd.encode('utf8'), salt)
+
 # Keep this out of source code repository - save in a file or a database
 VALID_USERNAME_PASSWORD_PAIRS = {
-    'hello': 'world'
+    'hello': hash_password('world')
 }
 
 external_stylesheets = ['https://codepen.io/chriddyp/pen/bWLwgP.css']


### PR DESCRIPTION
Encouraging users store plaintext passwords in a database seems like a bad idea. How about suggesting they store hashed passwords instead?