### PR TITLE
Support Dash v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ jobs:
   "python-2.7": &test-template
     docker:
       - image: circleci/python:2.7-stretch-browsers
-
     steps:
       - checkout
 
@@ -38,10 +37,11 @@ jobs:
           name: Test with pytest
           command: |
             . venv/bin/activate
-            python -m unittest -v tests.test_basic_auth_integration
-            python -m unittest -v tests.test_api_requests
-            python -m unittest -v tests.test_plotlyauth
-            python -m unittest -v tests.test_plotly_auth_integration
+            mkdir test-results
+            pytest --junitxml=test-results/junit.xml
+      
+      - store_test_results:
+          path: test-results
 
   "python-3.6":
     <<: *test-template

--- a/dash_auth/plotly_auth.py
+++ b/dash_auth/plotly_auth.py
@@ -13,8 +13,11 @@ import requests
 from hmac import compare_digest
 from six import iteritems
 
-import dash_html_components as html
-import dash_core_components as dcc
+try:
+    from dash import html, dcc
+except ImportError:
+    import dash_html_components as html
+    import dash_core_components as dcc
 from dash.dependencies import Output, Input
 
 from .oauth import OAuthBase, need_request_context

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,3 +9,4 @@ ipdb
 flake8
 retrying
 chromedriver
+pytest

--- a/tests/test_api_requests.py
+++ b/tests/test_api_requests.py
@@ -54,7 +54,7 @@ class TestRequestsCall(unittest.TestCase):
     def test_plotly_query(self, mock_get):
         result = plotly_query()
         self.assertEqual(result.json(), JSON_DATA)
-        self.failUnless(result.raise_for_status.called)
+        self.assertTrue(result.raise_for_status.called)
         self.assertEqual(mock_get.call_count, 1)
 
     @mock.patch(
@@ -77,7 +77,7 @@ class TestRequestsCall(unittest.TestCase):
         test_cases = [
             ['', [
                 'Invalid URL',
-                'No schema supplied',
+                'No scheme supplied',
                 'gettaddrinfo failed',
                 ['nodename nor servname provided, or not known',
                  'Name or service not known']
@@ -95,17 +95,13 @@ class TestRequestsCall(unittest.TestCase):
                  'Name or service not known']
             ]],
             ['https://expired.badssl.com', [
-                'Caused by SSLError(SSLError("bad handshake: Error([(',
-                'SSL routines',
-                'tls_process_server_certificate',
+                'Caused by SSLError(SSLError',
                 'certificate verify failed',
                 'gettaddrinfo: ',
                 "'104.154.89.105', 443"
             ]],
             ['https://self-signed.badssl.com', [
-                'Caused by SSLError(SSLError("bad handshake: Error([(',
-                'SSL routines',
-                'tls_process_server_certificate',
+                'Caused by SSLError(SSLError',
                 'certificate verify failed',
                 'gettaddrinfo',
                 "'104.154.89.105', 443"

--- a/tests/test_basic_auth_integration.py
+++ b/tests/test_basic_auth_integration.py
@@ -1,7 +1,11 @@
+
 from dash.dependencies import Input, Output
 import dash
-import dash_html_components as html
-import dash_core_components as dcc
+try:
+    from dash import html, dcc
+except ImportError:
+    import dash_html_components as html
+    import dash_core_components as dcc
 import requests
 
 

--- a/tests/test_plotly_auth_integration.py
+++ b/tests/test_plotly_auth_integration.py
@@ -4,8 +4,11 @@ import unittest
 import flask
 from dash.dependencies import Input, Output
 import dash
-import dash_html_components as html
-import dash_core_components as dcc
+try:
+    from dash import html, dcc
+except ImportError:
+    import dash_html_components as html
+    import dash_core_components as dcc
 import os
 import time
 from dash.exceptions import PreventUpdate

--- a/tests/test_plotlyauth.py
+++ b/tests/test_plotlyauth.py
@@ -2,7 +2,10 @@ from __future__ import absolute_import
 import time
 import unittest
 import dash
-import dash_html_components as html
+try:
+    from dash import html
+except ImportError:
+    import dash_html_components as html
 import os
 import six
 from six.moves import http_cookies


### PR DESCRIPTION
**What it does**
1. Add support for dash v2 imports (`from dash import html, dcc`).
2. Fix test errors in `test_api_requests.py`.
3. Set `store_test_results` in `.circlei/config.yml` to store test results for easier debugging.

**How is this helpful**
No more import warnings: _the dash_html_components package is deprecated. Please replace import dash_html_components as html ..._ when using dash-auth.

**Context**
This PR is meant to solve #121. #122 was on the right path so I based myself in that PR.

**Next steps**
There are still 19 failed tests which I think are all caused by the same problem The `users` dict is widely used throughout `test_plotly_auth_integration.py` but it requires environmental variables that are never defined (I could have missed something). 
<img width="465" alt="image" src="https://user-images.githubusercontent.com/43001823/155832747-07476876-e418-48c3-952d-83ff9ade79f5.png">

Thus, test such as this will fail
<img width="461" alt="image" src="https://user-images.githubusercontent.com/43001823/155832736-852bfe5b-7b9b-48b8-a436-076b5cb6b36e.png">



