### PR TITLE
Deprecated import

### DIFF
--- a/dash_auth/plotly_auth.py
+++ b/dash_auth/plotly_auth.py
@@ -13,8 +13,7 @@ import requests
 from hmac import compare_digest
 from six import iteritems
 
-import dash_html_components as html
-import dash_core_components as dcc
+from dash import dcc, html
 from dash.dependencies import Output, Input
 
 from .oauth import OAuthBase, need_request_context


### PR DESCRIPTION
The dash_html_components package is deprecated. Please replace
`import dash_html_components as html` with `from dash import html`
The dash_core_components package is deprecated. Please replace
`import dash_core_components as dcc` with `from dash import dcc`