### PR TITLE
fixed deprecated of html and dcc.

### DIFF
--- a/dash_auth/plotly_auth.py
+++ b/dash_auth/plotly_auth.py
@@ -13,8 +13,7 @@ import requests
 from hmac import compare_digest
 from six import iteritems
 
-import dash_html_components as html
-import dash_core_components as dcc
+from dash import html, dcc
 from dash.dependencies import Output, Input
 
 from .oauth import OAuthBase, need_request_context


### PR DESCRIPTION
modified
```
import dash_html_components as html
import dash_core_components as dcc
```
to
```
from dash import html, dcc
```

because I got an error as follows.

> /Users/yukik/miniforge3/envs/ml39/lib/python3.9/site-packages/dash_auth/plotly_auth.py:16: UserWarning: 
> The dash_html_components package is deprecated. Please replace
> `import dash_html_components as html` with `from dash import html`
>   import dash_html_components as html
> /Users/yukik/miniforge3/envs/ml39/lib/python3.9/site-packages/dash_auth/plotly_auth.py:17: UserWarning: 
> The dash_core_components package is deprecated. Please replace
> `import dash_core_components as dcc` with `from dash import dcc`
>   import dash_core_components as dcc