### PR TITLE
Make BasicAuth prompt for id/password on non-index pages.

### DIFF
--- a/dash_auth/basic_auth.py
+++ b/dash_auth/basic_auth.py
@@ -30,17 +30,11 @@ class BasicAuth(Auth):
 
     def auth_wrapper(self, f):
         def wrap(*args, **kwargs):
-            if not self.is_authorized():
-                return flask.Response(status=403)
+            if self.is_authorized():
+                return f(*args, **kwargs)
+            return self.login_request()
 
-            response = f(*args, **kwargs)
-            return response
         return wrap
 
     def index_auth_wrapper(self, original_index):
-        def wrap(*args, **kwargs):
-            if self.is_authorized():
-                return original_index(*args, **kwargs)
-            else:
-                return self.login_request()
-        return wrap
+        return self.auth_wrapper(original_index)

--- a/tests/test_basic_auth_integration.py
+++ b/tests/test_basic_auth_integration.py
@@ -33,7 +33,7 @@ def test_ba001_basic_auth_login_flow(dash_br, dash_thread_server):
 
     def test_failed_views(url):
         assert requests.get(url).status_code == 401
-        assert requests.get(url.strip("/") + "/_dash-layout").status_code == 403
+        assert requests.get(url.strip("/") + "/_dash-layout").status_code == 401
 
     test_failed_views(base_url)
 


### PR DESCRIPTION
Currently only the index page (`/`) prompts users to login, whereas other pages return a 403 error.

It would be a lot nicer to be able to share a page (especially with multi-pages) and that it just prompts the user to authenticate then an there rather than having to go through the index.