### PR TITLE
Adding user defined authentication function as parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Uses flask `before_request` to protect all endpoints rather than protecting routes present at instantiation time
+- Allows user to use user-defined authorization python function instead of a dictionary/list of usernames and passwords
 
 ## [2.0.0] - 2023-03-10
 ### Removed

--- a/README.md
+++ b/README.md
@@ -41,3 +41,20 @@ USER_PWD = {
 }
 BasicAuth(app, USER_PWD)
 ```
+
+One can also use an authorization python function instead of a dictionary/list of usernames and passwords:
+
+```python
+from dash import Dash
+from dash_auth import BasicAuth
+
+def authorization_function(username, password):
+    if (username == "hello") and (password == "world"):
+        return True
+    else:
+        return False
+
+
+app = Dash(__name__)
+BasicAuth(app, auth_func = authorization_function)
+```

--- a/dash_auth/basic_auth.py
+++ b/dash_auth/basic_auth.py
@@ -18,25 +18,27 @@ class BasicAuth(Auth):
         :param app: Dash app
         :param username_password_list: username:password list, either as a
             list of tuples or a dict
-        :param auth_func: python function accepting two string arguments (username, password) 
-            and returning a boolean (True if the user has access otherwise False).
+        :param auth_func: python function accepting two string
+            arguments (username, password) and returning a
+            boolean (True if the user has access otherwise False).
         """
         Auth.__init__(self, app)
         self._auth_func = auth_func
         if self._auth_func is not None:
             if username_password_list is not None:
-                raise ValueError("BasicAuth can only use authorization function (auth_func kwarg) "
-                                 "or username_password_list, it cannot use both.")
+                raise ValueError("BasicAuth can only use authorization "
+                                 "function (auth_func kwarg) or "
+                                 "username_password_list, it cannot use both.")
         else:
             if username_password_list is None:
-                raise ValueError("BasicAuth requires username/password map or user-defined authorization function.")
+                raise ValueError("BasicAuth requires username/password map "
+                                 "or user-defined authorization function.")
             else:
                 self._users = (
                     username_password_list
                     if isinstance(username_password_list, dict)
                     else {k: v for k, v in username_password_list}
                 )
-        
 
     def is_authorized(self):
         header = flask.request.headers.get('Authorization', None)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,4 @@ dash[testing]>=2
 requests[security]
 flake8
 flask
+pytest

--- a/tests/test_basic_auth_integration_auth_func.py
+++ b/tests/test_basic_auth_integration_auth_func.py
@@ -1,0 +1,91 @@
+from dash import Dash, Input, Output, dcc, html
+import requests
+import pytest
+
+from dash_auth import basic_auth
+
+TEST_USERS = {
+    "valid": [
+        ["hello", "world"],
+        ["hello2", "wo:rld"]
+    ],
+    "invalid": [
+        ["hello", "password"]
+    ],
+}
+
+
+# Test using auth_func instead of TEST_USERS directly
+def auth_function(username, password):
+    if [username, password] in TEST_USERS["valid"]:
+        return True
+    else:
+        return False
+
+
+def test_ba002_basic_auth_login_flow(dash_br, dash_thread_server):
+    app = Dash(__name__)
+    app.layout = html.Div([
+        dcc.Input(id="input", value="initial value"),
+        html.Div(id="output")
+    ])
+
+    @app.callback(Output("output", "children"), Input("input", "value"))
+    def update_output(new_value):
+        return new_value
+
+    basic_auth.BasicAuth(app, auth_func=auth_function)
+
+    dash_thread_server(app)
+    base_url = dash_thread_server.url
+
+    def test_failed_views(url):
+        assert requests.get(url).status_code == 401
+        assert requests.get(url.strip("/") + "/_dash-layout").status_code == 401
+
+    test_failed_views(base_url)
+
+    for user, password in TEST_USERS["invalid"]:
+        test_failed_views(base_url.replace("//", f"//{user}:{password}@"))
+
+    # Test login for each user:
+    for user, password in TEST_USERS["valid"]:
+        # login using the URL instead of the alert popup
+        # selenium has no way of accessing the alert popup
+        dash_br.driver.get(base_url.replace("//", f"//{user}:{password}@"))
+
+        # the username:password@host url doesn"t work right now for dash
+        # routes, but it saves the credentials as part of the browser.
+        # visiting the page again will use the saved credentials
+        dash_br.driver.get(base_url)
+        dash_br.wait_for_text_to_equal("#output", "initial value")
+
+
+# Test incorrect initialization of BasicAuth
+def both_dict_and_func(dash_br, dash_thread_server):
+    app = Dash(__name__)
+    app.layout = html.Div([
+        dcc.Input(id="input", value="initial value"),
+        html.Div(id="output")
+    ])
+
+    basic_auth.BasicAuth(app, TEST_USERS["valid"], auth_func=auth_function)
+    return True
+
+
+def both_no_auth_func_or_dict(dash_br, dash_thread_server):
+    app = Dash(__name__)
+    app.layout = html.Div([
+        dcc.Input(id="input", value="initial value"),
+        html.Div(id="output")
+    ])
+    basic_auth.BasicAuth(app)
+    return True
+
+
+def test_ba003_basic_auth_login_flow(dash_br, dash_thread_server):
+    with pytest.raises(ValueError):
+        both_dict_and_func(dash_br, dash_thread_server)
+    with pytest.raises(ValueError):
+        both_no_auth_func_or_dict(dash_br, dash_thread_server)
+    return

--- a/usage.py
+++ b/usage.py
@@ -6,6 +6,7 @@ VALID_USERNAME_PASSWORD_PAIRS = {
     'hello': 'world'
 }
 
+
 # Authorization function defined by developer
 # (can be used instead of VALID_USERNAME_PASSWORD_PAIRS [Example 2 below])
 def authorization_function(username, password):
@@ -13,6 +14,7 @@ def authorization_function(username, password):
         return True
     else:
         return False
+
 
 external_stylesheets = ['https://codepen.io/chriddyp/pen/bWLwgP.css']
 app = Dash(__name__, external_stylesheets=external_stylesheets)

--- a/usage.py
+++ b/usage.py
@@ -6,11 +6,15 @@ VALID_USERNAME_PASSWORD_PAIRS = {
     'hello': 'world'
 }
 
+def auth_func(username, password):
+    return "hello", "world"
+
 external_stylesheets = ['https://codepen.io/chriddyp/pen/bWLwgP.css']
 app = Dash(__name__, external_stylesheets=external_stylesheets)
 auth = dash_auth.BasicAuth(
     app,
-    VALID_USERNAME_PASSWORD_PAIRS
+    VALID_USERNAME_PASSWORD_PAIRS,
+    auth_func
 )
 
 app.layout = html.Div([

--- a/usage.py
+++ b/usage.py
@@ -6,16 +6,22 @@ VALID_USERNAME_PASSWORD_PAIRS = {
     'hello': 'world'
 }
 
-def auth_func(username, password):
-    return "hello", "world"
+# Authorization function defined by developer
+# (can be used instead of VALID_USERNAME_PASSWORD_PAIRS [Example 2 below])
+def authorization_function(username, password):
+    if (username == "hello") and (password == "world"):
+        return True
+    else:
+        return False
 
 external_stylesheets = ['https://codepen.io/chriddyp/pen/bWLwgP.css']
 app = Dash(__name__, external_stylesheets=external_stylesheets)
-auth = dash_auth.BasicAuth(
-    app,
-    VALID_USERNAME_PASSWORD_PAIRS,
-    auth_func
-)
+
+# Example 1 (using username/password map)
+auth = dash_auth.BasicAuth(app, VALID_USERNAME_PASSWORD_PAIRS)
+
+# Example 2 (using authorization function)
+# auth = dash_auth.BasicAuth(app, auth_func=authorization_function)
 
 app.layout = html.Div([
     html.H1('Welcome to the app'),


### PR DESCRIPTION
This pull request would allow users to pass their own python function to dash_auth.BasicAuth() so that the usernames and passwords do not have to be stored as plain strings and can simply be stored as the result of a user defined function (e.g. the hash of the password can be stored instead of the password itself).