### PR TITLE
Bugfix, body["inputs"] are sometimes not dict but empty list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fix when looking for callback inputs that are not in the right format when checking for whitelisted routes
+
 ## [2.2.0] - 2024-02-05
 ### Added
 - Possibility to whitelist routes with the `add_public_routes` utility function, the routes should follow Flask route syntax

--- a/dash_auth/auth.py
+++ b/dash_auth/auth.py
@@ -66,8 +66,9 @@ class Auth(ABC):
                 # should be checked against the public routes
                 pathname = next(
                     (
-                        inp["value"] for inp in body["inputs"]
-                        if inp["property"] == "pathname"
+                        inp.get("value") for inp in body["inputs"]
+                        if isinstance(inp, dict)
+                        and inp.get("property") == "pathname"
                     ),
                     None,
                 )


### PR DESCRIPTION
Values in `body["inputs"]` are not dict but lists when working with pattern-matching callbacks. Ensure that this doesn't fail when this is the case.