### PR TITLE
auth-flow adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ The following utilities are defined:
   * eg `dash.register_page('test', path_template='/test/<test>', layout=protect_layout({'groups': ['testing']})(Layout))`
 * `protect_layouts`: A function that will iterate through all pages and called `protect_layout` on the `layout`, 
   * passes `kwargs` to `protect_layout` if not already defined in the `layout`
-  * eg `protect_layouts(missing_permissions_output=html.Div("I'm sorry ,Dave, I'm afraid I can't do that"))`
+  * eg `protect_layouts(missing_permissions_output=html.Div("I'm sorry, Dave, I'm afraid I can't do that"))`
 
 NOTE: user info is stored in the session so make sure you define a secret_key on the Flask server
 to use this feature.

--- a/README.md
+++ b/README.md
@@ -382,7 +382,9 @@ The following utilities are defined:
   and with the right group permissions.
 * `protect_layout`: A function that will protect a layout similar to how `protected_callback` works.
   * eg `dash.register_page('test', path_template='/test/<test>', layout=protect_layout({'groups': ['testing']})(Layout))`
-* `protect_layouts`: A function that will iterate through all pages and called `protect_layout` on the `layout`.
+* `protect_layouts`: A function that will iterate through all pages and called `protect_layout` on the `layout`, 
+  * passes `kwargs` to `protect_layout` if not already defined in the `layout`
+  * eg `protect_layouts(missing_permissions_output=html.Div("I'm sorry ,Dave, I'm afraid I can't do that"))`
 
 NOTE: user info is stored in the session so make sure you define a secret_key on the Flask server
 to use this feature.

--- a/README.md
+++ b/README.md
@@ -464,3 +464,21 @@ When using the functions, the following dictionaries will be passed respectively
 the function you provide:
  - `group_lookup`: `{'path': '/test'}` => `pull_groups(path)`
  - `restricted_users_lookup`: `{'path': '/test'}` => `pull_users(path)`
+
+### Restricting layouts
+
+`dash_auth` by default will cater your page layouts that are in your public routes or where the user is authenticated.
+However, it is possible to lock down layouts by passing these additional arguments to `OIDCAuth` or `BasicAuth` methods:
+
+```python
+auth_protect_layouts=True,
+auth_protect_layouts_kwargs=dict(missing_permissions_output=html.Div('you cant get me')),
+page_container='_pages_content'
+```
+
+Passing `auth_protect_layouts` tells the app to invoke the `protect_layouts` with the `public_routes` passed to 
+not protect the layouts of public routes.
+Passing `auth_protect_layouts_kwargs` is the same are the additional `kwargs` passed to the function
+By default, the app will check any non-public callback that has the `pathname` as an input, 
+when you pass `page_container` as the `id` of your container element for a page container,
+it will only check the route if it is an output.

--- a/README.md
+++ b/README.md
@@ -380,10 +380,8 @@ The following utilities are defined:
   or missing group permission.
 * `protected_callback`: A callback that only runs if the user is authenticated
   and with the right group permissions.
-* `protect_layout`: A function that will protect a layout similar to how `protected_callback` works.
-  * eg `dash.register_page('test', path_template='/test/<test>', layout=protect_layout({'groups': ['testing']})(Layout))`
-* `protect_layouts`: A function that will iterate through all pages and called `protect_layout` on the `layout`, 
-  * passes `kwargs` to `protect_layout` if not already defined in the `layout`
+* `protect_layouts`: A function that will iterate through all pages and called `protected` on the `layout`, 
+  * passes `kwargs` to `protected` if not already defined in the `layout`
   * eg `protect_layouts(missing_permissions_output=html.Div("I'm sorry, Dave, I'm afraid I can't do that"))`
 
 NOTE: user info is stored in the session so make sure you define a secret_key on the Flask server
@@ -476,7 +474,7 @@ auth_protect_layouts_kwargs=dict(missing_permissions_output=html.Div('you cant g
 page_container='_pages_content'
 ```
 
-Passing `auth_protect_layouts` tells the app to invoke the `protect_layouts` with the `public_routes` passed to 
+Passing `auth_protect_layouts` tells the app to invoke the `protected` with the `public_routes` passed to 
 not protect the layouts of public routes.
 Passing `auth_protect_layouts_kwargs` is the same are the additional `kwargs` passed to the function
 By default, the app will check any non-public callback that has the `pathname` as an input, 

--- a/dash_auth/__init__.py
+++ b/dash_auth/__init__.py
@@ -1,8 +1,14 @@
 from .public_routes import add_public_routes, public_callback
 from .basic_auth import BasicAuth
 from .group_protection import (
-    list_groups, check_groups, protected, protected_callback
+    list_groups,
+    check_groups,
+    protected,
+    protected_callback,
+    protect_layouts,
+    protect_layout,
 )
+
 # oidc auth requires authlib, install with `pip install dash-auth[oidc]`
 try:
     from .oidc_auth import OIDCAuth, get_oauth
@@ -16,6 +22,8 @@ __all__ = [
     "check_groups",
     "list_groups",
     "get_oauth",
+    "protect_layout",
+    "protect_layouts",
     "protected",
     "protected_callback",
     "public_callback",

--- a/dash_auth/__init__.py
+++ b/dash_auth/__init__.py
@@ -6,7 +6,6 @@ from .group_protection import (
     protected,
     protected_callback,
     protect_layouts,
-    protect_layout,
 )
 
 # oidc auth requires authlib, install with `pip install dash-auth[oidc]`
@@ -22,7 +21,6 @@ __all__ = [
     "check_groups",
     "list_groups",
     "get_oauth",
-    "protect_layout",
     "protect_layouts",
     "protected",
     "protected_callback",

--- a/dash_auth/auth.py
+++ b/dash_auth/auth.py
@@ -6,7 +6,9 @@ from dash import Dash
 from flask import request
 
 from .public_routes import (
-    add_public_routes, get_public_callbacks, get_public_routes
+    add_public_routes,
+    get_public_callbacks,
+    get_public_routes,
 )
 from .group_protection import protect_layouts
 
@@ -19,7 +21,7 @@ class Auth(ABC):
         auth_protect_layouts: Optional[Union[dict, bool]] = False,
         auth_protect_layouts_kwargs: Optional[dict] = None,
         page_container: Optional[str] = None,
-        **obsolete
+        **obsolete,
     ):
         """Auth base class for authentication in Dash.
 
@@ -48,7 +50,10 @@ class Auth(ABC):
         if public_routes is not None:
             add_public_routes(app, public_routes)
         if self.auth_protect_layouts:
-            protect_layouts(public_routes=get_public_routes(self.app), **(auth_protect_layouts_kwargs or {}))
+            protect_layouts(
+                public_routes=get_public_routes(self.app),
+                **(auth_protect_layouts_kwargs or {}),
+            )
 
     def _protect(self):
         """Add a before_request authentication check on all routes.
@@ -79,19 +84,21 @@ class Auth(ABC):
 
                 pathname = next(
                     (
-                        inp.get("value") for inp in body["inputs"]
+                        inp.get("value")
+                        for inp in body["inputs"]
                         if isinstance(inp, dict)
-                           and inp.get("property") == "pathname"
+                        and inp.get("property") == "pathname"
                     ),
                     None,
                 )
                 if self.page_container:
                     page_container_test = next(
                         (
-                            out for out in body["outputs"]
+                            out
+                            for out in body["outputs"]
                             if isinstance(out, dict)
-                               and out.get('id') == self.page_container
-                               and out.get("property") == "children"
+                            and out.get("id") == self.page_container
+                            and out.get("property") == "children"
                         ),
                         None,
                     )
@@ -102,7 +109,11 @@ class Auth(ABC):
                 # such a callback will be a routing callback and the pathname
                 # should be checked against the public routes
                 if not self.auth_protect_layouts:
-                    if pathname and page_container_test and public_routes.test(pathname):
+                    if (
+                        pathname
+                        and page_container_test
+                        and public_routes.test(pathname)
+                    ):
                         return None
                 else:
                     # protected by layout

--- a/dash_auth/auth.py
+++ b/dash_auth/auth.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Optional, Union
 
 from dash import Dash
 from flask import request
@@ -8,6 +8,7 @@ from flask import request
 from .public_routes import (
     add_public_routes, get_public_callbacks, get_public_routes
 )
+from .group_protection import protect_layouts
 
 
 class Auth(ABC):
@@ -15,6 +16,9 @@ class Auth(ABC):
         self,
         app: Dash,
         public_routes: Optional[list] = None,
+        auth_protect_layouts: Optional[Union[dict, bool]] = False,
+        auth_protect_layouts_kwargs: Optional[dict] = None,
+        page_container: Optional[str] = None,
         **obsolete
     ):
         """Auth base class for authentication in Dash.
@@ -22,6 +26,13 @@ class Auth(ABC):
         :param app: Dash app
         :param public_routes: list of public routes, routes should follow the
             Flask route syntax
+        :param auth_protect_layouts: bool, defaults to False.
+            If true, runs protect_layout()
+        :param auth_protect_layouts_kwargs: dict, if provided is passed to the
+            protect_layout as kwargs
+        :param page_container: string, id of the page container in the app.
+            If not provided, this will set the page_container_test to True,
+            meaning all pathname callbacks will be judged.
         """
 
         # Deprecated arguments
@@ -32,8 +43,12 @@ class Auth(ABC):
 
         self.app = app
         self._protect()
+        self.auth_protect_layouts = auth_protect_layouts
+        self.page_container = page_container
         if public_routes is not None:
             add_public_routes(app, public_routes)
+        if self.auth_protect_layouts:
+            protect_layouts(public_routes=get_public_routes(self.app), **(auth_protect_layouts_kwargs or {}))
 
     def _protect(self):
         """Add a before_request authentication check on all routes.
@@ -50,6 +65,7 @@ class Auth(ABC):
 
             public_routes = get_public_routes(self.app)
             public_callbacks = get_public_callbacks(self.app)
+
             # Handle Dash's callback route:
             # * Check whether the callback is marked as public
             # * Check whether the callback is performed on route change in
@@ -61,19 +77,37 @@ class Auth(ABC):
                 if body["output"] in public_callbacks:
                     return None
 
-                # Check whether the callback has an input using the pathname,
-                # such a callback will be a routing callback and the pathname
-                # should be checked against the public routes
                 pathname = next(
                     (
                         inp.get("value") for inp in body["inputs"]
                         if isinstance(inp, dict)
-                        and inp.get("property") == "pathname"
+                           and inp.get("property") == "pathname"
                     ),
                     None,
                 )
-                if pathname and public_routes.test(pathname):
-                    return None
+                if self.page_container:
+                    page_container_test = next(
+                        (
+                            out for out in body["outputs"]
+                            if isinstance(out, dict)
+                               and out.get('id') == self.page_container
+                               and out.get("property") == "children"
+                        ),
+                        None,
+                    )
+                else:
+                    page_container_test = True
+
+                # Check whether the callback has an input using the pathname,
+                # such a callback will be a routing callback and the pathname
+                # should be checked against the public routes
+                if not self.auth_protect_layouts:
+                    if pathname and page_container_test and public_routes.test(pathname):
+                        return None
+                else:
+                    # protected by layout
+                    if pathname and page_container_test:
+                        return None
 
             # If the route is not a callback route, check whether the path
             # matches a public route, or whether the request is authorised

--- a/dash_auth/basic_auth.py
+++ b/dash_auth/basic_auth.py
@@ -19,7 +19,10 @@ class BasicAuth(Auth):
         user_groups: Optional[
             Union[UserGroups, Callable[[str], UserGroups]]
         ] = None,
-        secret_key: str = None
+        secret_key: str = None,
+        auth_protect_layouts: Optional[bool] = False,
+        auth_protect_layouts_kwargs: Optional[dict] = None,
+        page_container: Optional[str] = None,
     ):
         """Add basic authentication to Dash.
 
@@ -46,8 +49,19 @@ class BasicAuth(Auth):
             Note that you should not do this dynamically:
             you should create a key and then assign the value of
             that key in your code.
+        :param auth_protect_layouts: bool, defaults to False.
+            If true, runs protect_layout()
+        :param auth_protect_layouts_kwargs: dict, if provided is passed to the
+            protect_layout as kwargs
+        :param page_container: string, id of the page container in the app.
+            If not provided, this will set the page_container_test to True,
+            meaning all pathname callbacks will be judged.
         """
-        super().__init__(app, public_routes=public_routes)
+        super().__init__(app, public_routes=public_routes,
+                         auth_protect_layouts=auth_protect_layouts,
+                        auth_protect_layouts_kwargs=auth_protect_layouts_kwargs,
+                         page_container=page_container
+        )
         self._auth_func = auth_func
         self._user_groups = user_groups
         if secret_key is not None:

--- a/dash_auth/basic_auth.py
+++ b/dash_auth/basic_auth.py
@@ -57,10 +57,12 @@ class BasicAuth(Auth):
             If not provided, this will set the page_container_test to True,
             meaning all pathname callbacks will be judged.
         """
-        super().__init__(app, public_routes=public_routes,
-                         auth_protect_layouts=auth_protect_layouts,
-                        auth_protect_layouts_kwargs=auth_protect_layouts_kwargs,
-                         page_container=page_container
+        super().__init__(
+            app,
+            public_routes=public_routes,
+            auth_protect_layouts=auth_protect_layouts,
+            auth_protect_layouts_kwargs=auth_protect_layouts_kwargs,
+            page_container=page_container,
         )
         self._auth_func = auth_func
         self._user_groups = user_groups
@@ -88,12 +90,12 @@ class BasicAuth(Auth):
                 )
 
     def is_authorized(self):
-        header = flask.request.headers.get('Authorization', None)
+        header = flask.request.headers.get("Authorization", None)
         if not header:
             return False
-        username_password = base64.b64decode(header.split('Basic ')[1])
-        username_password_utf8 = username_password.decode('utf-8')
-        username, password = username_password_utf8.split(':', 1)
+        username_password = base64.b64decode(header.split("Basic ")[1])
+        username_password_utf8 = username_password.decode("utf-8")
+        username, password = username_password_utf8.split(":", 1)
         authorized = False
         if self._auth_func is not None:
             try:
@@ -122,7 +124,7 @@ class BasicAuth(Auth):
 
     def login_request(self):
         return flask.Response(
-            'Login Required',
-            headers={'WWW-Authenticate': 'Basic realm="User Visible Realm"'},
-            status=401
+            "Login Required",
+            headers={"WWW-Authenticate": 'Basic realm="User Visible Realm"'},
+            status=401,
         )

--- a/dash_auth/group_protection.py
+++ b/dash_auth/group_protection.py
@@ -76,7 +76,7 @@ def check_groups(
             restricted_users = restricted_users(**restricted_users_lookup)
         if session['user'][user_session_key] in restricted_users:
             # User is restricted
-            return None
+            return False
     if callable(groups):
         groups = groups(**group_lookup)
     if groups is None:

--- a/dash_auth/group_protection.py
+++ b/dash_auth/group_protection.py
@@ -336,6 +336,14 @@ def protect_layout(pg: dict = None) -> Callable:
 
 
 def protect_layouts(**kwargs) -> str:
-    for pg in dash.page_registry.values():
-        pg["layout"] = protect_layout({**kwargs, **pg})(pg["layout"])
-    return "your layouts are now protected"
+    if 'pages_folder' in dash.get_app().config:
+        for pg in dash.page_registry.values():
+            if kwargs.get('public_routes'):
+                if isinstance(kwargs.get('public_routes'), list):
+                    if not (pg['path'] in kwargs.get('public_routes') or pg.get('path_template') in kwargs.get('public_routes')):
+                        pg["layout"] = protect_layout({**kwargs, **pg})(pg["layout"])
+                elif not (kwargs.get('public_routes').test(pg.get('path_template')) or kwargs.get('public_routes').test(pg['path'])):
+                    pg["layout"] = protect_layout({**kwargs, **pg})(pg["layout"])
+            else:
+                pg["layout"] = protect_layout({**kwargs, **pg})(pg["layout"])
+        return "your layouts are now protected"

--- a/dash_auth/group_protection.py
+++ b/dash_auth/group_protection.py
@@ -335,7 +335,7 @@ def protect_layout(pg: dict = None) -> Callable:
     return decorator
 
 
-def protect_layouts() -> str:
+def protect_layouts(**kwargs) -> str:
     for pg in dash.page_registry.values():
-        pg["layout"] = protect_layout(pg)(pg["layout"])
+        pg["layout"] = protect_layout({**kwargs, **pg})(pg["layout"])
     return "your layouts are now protected"

--- a/dash_auth/group_protection.py
+++ b/dash_auth/group_protection.py
@@ -324,7 +324,7 @@ def protect_layouts(**kwargs) -> str:
             filtered_kwargs = filter_kwargs(expected_keys, **{**kwargs, **pg})
             if filtered_kwargs.get("unauthenticated_output") is None:
                 filtered_kwargs["unauthenticated_output"] = html.Div(
-                    "you do not have access to this content"
+                    "You do not have access to this content."
                 )
             if kwargs.get("public_routes"):
                 if isinstance(kwargs.get("public_routes"), list):

--- a/dash_auth/group_protection.py
+++ b/dash_auth/group_protection.py
@@ -336,14 +336,25 @@ def protect_layout(pg: dict = None) -> Callable:
 
 
 def protect_layouts(**kwargs) -> str:
-    if 'pages_folder' in dash.get_app().config:
+    if "pages_folder" in dash.get_app().config:
         for pg in dash.page_registry.values():
-            if kwargs.get('public_routes'):
-                if isinstance(kwargs.get('public_routes'), list):
-                    if not (pg['path'] in kwargs.get('public_routes') or pg.get('path_template') in kwargs.get('public_routes')):
-                        pg["layout"] = protect_layout({**kwargs, **pg})(pg["layout"])
-                elif not (kwargs.get('public_routes').test(pg.get('path_template')) or kwargs.get('public_routes').test(pg['path'])):
-                    pg["layout"] = protect_layout({**kwargs, **pg})(pg["layout"])
+            if kwargs.get("public_routes"):
+                if isinstance(kwargs.get("public_routes"), list):
+                    if not (
+                        pg["path"] in kwargs.get("public_routes")
+                        or pg.get("path_template")
+                        in kwargs.get("public_routes")
+                    ):
+                        pg["layout"] = protect_layout({**kwargs, **pg})(
+                            pg["layout"]
+                        )
+                elif not (
+                    kwargs.get("public_routes").test(pg.get("path_template"))
+                    or kwargs.get("public_routes").test(pg["path"])
+                ):
+                    pg["layout"] = protect_layout({**kwargs, **pg})(
+                        pg["layout"]
+                    )
             else:
                 pg["layout"] = protect_layout({**kwargs, **pg})(pg["layout"])
         return "your layouts are now protected"

--- a/dash_auth/oidc_auth.py
+++ b/dash_auth/oidc_auth.py
@@ -306,11 +306,11 @@ class OIDCAuth(Auth):
             if callable(self._user_groups):
                 session["user"]["groups"] = self._user_groups(
                     user.get("email")
-                )
+                ) + (session["user"].get("groups") or [])
             elif self._user_groups:
                 session["user"]["groups"] = self._user_groups.get(
                     user.get("email"), []
-                )
+                ) + (session["user"].get("groups") or [])
             if "offline_access" in oauth_client.client_kwargs["scope"]:
                 session["refresh_token"] = token.get("refresh_token")
             if self.log_signins:

--- a/dash_auth/oidc_auth.py
+++ b/dash_auth/oidc_auth.py
@@ -254,7 +254,7 @@ class OIDCAuth(Auth):
                 return redirect(self.idp_selection_route)
             # If only one provider is registered, we don't need to
             # ask the user to pick one, just use the one
-            elif len(self.oauth._registry) == 1:
+            if len(self.oauth._registry) == 1:
                 idp = next(iter(self.oauth._clients))
             else:
                 return (

--- a/dash_auth/oidc_auth.py
+++ b/dash_auth/oidc_auth.py
@@ -107,10 +107,13 @@ class OIDCAuth(Auth):
         """
         if idp_selection_route:
             public_routes = [idp_selection_route, *public_routes]
-        super().__init__(app, public_routes=public_routes,
-                         auth_protect_layouts=auth_protect_layouts,
-                         auth_protect_layouts_kwargs=auth_protect_layouts_kwargs,
-                         page_container=page_container)
+        super().__init__(
+            app,
+            public_routes=public_routes,
+            auth_protect_layouts=auth_protect_layouts,
+            auth_protect_layouts_kwargs=auth_protect_layouts_kwargs,
+            page_container=page_container,
+        )
 
         if isinstance(force_https_callback, str):
             self.force_https_callback = force_https_callback in os.environ

--- a/dash_auth/oidc_auth.py
+++ b/dash_auth/oidc_auth.py
@@ -35,7 +35,7 @@ class OIDCAuth(Auth):
         logout_page: Union[str, Response] = None,
         secure_session: bool = False,
         user_groups: Optional[
-            Union[UserGroups, Callable[[str], UserGroups]]
+            Union[UserGroups, Callable[[str], List[str]]]
         ] = None,
         login_user_callback: Callable = None,
         auth_protect_layouts: Optional[bool] = False,

--- a/dash_auth/oidc_auth.py
+++ b/dash_auth/oidc_auth.py
@@ -38,6 +38,9 @@ class OIDCAuth(Auth):
             Union[UserGroups, Callable[[str], UserGroups]]
         ] = None,
         login_user_callback: Callable = None,
+        auth_protect_layouts: Optional[bool] = False,
+        auth_protect_layouts_kwargs: Optional[dict] = None,
+        page_container: Optional[str] = None,
     ):
         """Secure a Dash app through OpenID Connect.
 
@@ -89,13 +92,25 @@ class OIDCAuth(Auth):
             (userinfo, idp), where userinfo is normally a dict
             (request form or results from the idp).
             This must return a flask response or redirect.
+        :param auth_protect_layouts: bool, defaults to False.
+            If true, runs protect_layout()
+        :param auth_protect_layouts_kwargs: dict, if provided is passed to the
+            protect_layout as kwargs
+        :param page_container: string, id of the page container in the app.
+            If not provided, this will set the page_container_test to True,
+            meaning all pathname callbacks will be judged.
 
         Raises
         ------
         Exception
             Raise an exception if the app.server.secret_key is not defined
         """
-        super().__init__(app, public_routes=public_routes)
+        if idp_selection_route:
+            public_routes = [idp_selection_route, *public_routes]
+        super().__init__(app, public_routes=public_routes,
+                         auth_protect_layouts=auth_protect_layouts,
+                         auth_protect_layouts_kwargs=auth_protect_layouts_kwargs,
+                         page_container=page_container)
 
         if isinstance(force_https_callback, str):
             self.force_https_callback = force_https_callback in os.environ

--- a/dash_auth/oidc_auth.py
+++ b/dash_auth/oidc_auth.py
@@ -79,12 +79,16 @@ class OIDCAuth(Auth):
             Page seen by the user after logging out,
             by default None which will default to a simple logged out message
         secure_session: bool, optional
-            Whether to ensure the session is secure, setting the flasck config
+            Whether to ensure the session is secure, setting the flask config
             SESSION_COOKIE_SECURE and SESSION_COOKIE_HTTPONLY to True,
             by default False
         user_groups: a dict or a function returning a dict
             Optional group for each user, allowing to protect routes and
             callbacks depending on user groups
+        login_user_callback: python function accepting two arguments
+            (userinfo, idp), where userinfo is normally a dict
+            (request form or results from the idp).
+            This must return a flask response or redirect.
 
         Raises
         ------
@@ -283,11 +287,11 @@ class OIDCAuth(Auth):
             session["idp"] = idp
             if callable(self._user_groups):
                 session["user"]["groups"] = self._user_groups(
-                    user.get('email')
+                    user.get("email")
                 )
             elif self._user_groups:
                 session["user"]["groups"] = self._user_groups.get(
-                    user.get('email'), []
+                    user.get("email"), []
                 )
             if "offline_access" in oauth_client.client_kwargs["scope"]:
                 session["refresh_token"] = token.get("refresh_token")

--- a/dash_auth/oidc_auth.py
+++ b/dash_auth/oidc_auth.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 
 UserGroups = Dict[str, List[str]]
 
+
 class OIDCAuth(Auth):
     """Implements auth via OpenID."""
 

--- a/dash_auth/public_routes.py
+++ b/dash_auth/public_routes.py
@@ -20,6 +20,7 @@ BASE_PUBLIC_ROUTES = [
     "/_dash-dependencies",
     "/_favicon.ico",
     "/_reload-hash",
+    "/favicon.ico",
 ]
 PUBLIC_ROUTES = "PUBLIC_ROUTES"
 PUBLIC_CALLBACKS = "PUBLIC_CALLBACKS"

--- a/tests/test_oidc_auth.py
+++ b/tests/test_oidc_auth.py
@@ -133,7 +133,7 @@ def test_oa002_oidc_auth_login_fail(dash_thread_server):
         assert requests.get(url).status_code == 200
 
     test_unauthorized(base_url)
-    test_authorized(os.path.join(base_url, "public"))
+    test_authorized('/'.join([base_url, "public"]))
 
 
 @patch("authlib.integrations.flask_client.apps.FlaskOAuth2App.authorize_redirect", valid_authorize_redirect)
@@ -173,16 +173,16 @@ def test_oa003_oidc_auth_login_several_idp(dash_br, dash_thread_server):
     assert requests.get(base_url).status_code == 400
 
     # Login with IDP1
-    assert requests.get(os.path.join(base_url, "oidc/idp1/login")).status_code == 200
+    assert requests.get('/'.join([base_url, "oidc/idp1/login"])).status_code == 200
 
     # Logout
-    assert requests.get(os.path.join(base_url, "oidc/logout")).status_code == 200
+    assert requests.get('/'.join([base_url, "oidc/logout"])).status_code == 200
 
     assert requests.get(base_url).status_code == 400
 
     # Login with IDP2
-    assert requests.get(os.path.join(base_url, "oidc/idp2/login")).status_code == 200
+    assert requests.get('/'.join([base_url, "oidc/idp2/login"])).status_code == 200
 
-    dash_br.driver.get(os.path.join(base_url, "oidc/idp2/login"))
+    dash_br.driver.get('/'.join([base_url, "oidc/idp2/login"]))
     dash_br.driver.get(base_url)
     dash_br.wait_for_text_to_equal("#output1", "initial value")


### PR DESCRIPTION
added:
- user groups to the OIDC flow
- added the ability to pass your own login_user_callback to be able to customize the flow
- restritected users as a list or a function
- when a function is passed, it will execute during the function of `check_groups` with the `restricted_users_lookup` dict passed as kwargs
- this will also use a `user_session_key` to know whether this is matched in the returning list of `restricted_users`
- `protect_layouts` to protect all layouts in the app
- `auth_protect_layouts` tells the app to invoke the `protect_layouts` with the `public_routes` passed to
not protect the layouts of public routes.
- `auth_protect_layouts_kwargs` is the same are the additional `kwargs` passed to the function
- `page_container` as the `id` of your container element for a page container,
it will only check the route if it is an output.

changed:
- if a `idp_selection_route` is available, it will cater this even if there is only one provider, this allows for legacy logins
- groups is now a list of strings or a function
- when a function is passed, it will execute during the function of `check_groups` with the `group_lookup` dict passed as kwargs