### PR TITLE
Pass query params to IDP authorize URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,9 @@ def login_handler():
         idp = request.args.get("idp")
 
     if idp is not None:
+        # NOTE: You can pass additional query parameters to the authorization
+        # URL by setting them on thd oidc_login route
+        # e.g., url_for("oidc_login", idp=idp, login_hint="my@email.com")
         return redirect(url_for("oidc_login", idp=idp))
 
     return """<div>

--- a/dash_auth/oidc_auth.py
+++ b/dash_auth/oidc_auth.py
@@ -233,10 +233,8 @@ class OIDCAuth(Auth):
 
         redirect_uri = self._create_redirect_uri(idp)
         oauth_client = self.get_oauth_client(idp)
-        authorize_kwargs = (
-            self.get_oauth_kwargs(idp).get("authorize_redirect_kwargs", {})
-            | dict(request.values)
-        )
+        authorize_kwargs = self.get_oauth_kwargs(idp).get("authorize_redirect_kwargs", {})
+        authorize_kwargs.update(dict(request.values))
 
         return oauth_client.authorize_redirect(
             redirect_uri, **authorize_kwargs

--- a/dash_auth/oidc_auth.py
+++ b/dash_auth/oidc_auth.py
@@ -233,10 +233,13 @@ class OIDCAuth(Auth):
 
         redirect_uri = self._create_redirect_uri(idp)
         oauth_client = self.get_oauth_client(idp)
-        oauth_kwargs = self.get_oauth_kwargs(idp)
+        authorize_kwargs = (
+            self.get_oauth_kwargs(idp).get("authorize_redirect_kwargs", {})
+            | dict(request.values)
+        )
+
         return oauth_client.authorize_redirect(
-            redirect_uri,
-            **oauth_kwargs.get("authorize_redirect_kwargs", {}),
+            redirect_uri, **authorize_kwargs
         )
 
     def logout(self):  # pylint: disable=C0116

--- a/dash_auth/oidc_auth.py
+++ b/dash_auth/oidc_auth.py
@@ -233,7 +233,9 @@ class OIDCAuth(Auth):
 
         redirect_uri = self._create_redirect_uri(idp)
         oauth_client = self.get_oauth_client(idp)
-        authorize_kwargs = self.get_oauth_kwargs(idp).get("authorize_redirect_kwargs", {})
+        authorize_kwargs = self.get_oauth_kwargs(idp).get(
+            "authorize_redirect_kwargs", {}
+        )
         authorize_kwargs.update(dict(request.values))
 
         return oauth_client.authorize_redirect(

--- a/dash_auth/oidc_auth.py
+++ b/dash_auth/oidc_auth.py
@@ -57,6 +57,9 @@ class OIDCAuth(Auth):
         login_route : str, optional
             The route for the login function, it requires a <idp>
             placeholder, by default "/oidc/<idp>/login".
+            NOTE: Query parameters at this login route will be passed on to
+            the IDP authorization endpoint, e.g., add a `login_hint` by
+            redirecting to /oidc/my-idp/login?login_hint=my@email.com
         logout_route : str, optional
             The route for the logout function, by default "/oidc/logout".
         callback_route : str, optional


### PR DESCRIPTION
Allow to pass additional query params to the authorize URL from the IDP.

For instance passing `login_hint` can be done by redirecting to `/oidc/<idp>/login?login_hint=my@email.com`