### PR TITLE
Use Dash's create_callback_id to get the callback id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Allow to define a custom user management via the `after_logged_in` method #156
 
 ### Changed
-- Updated the `public_callback` to work in more cases
+- Updated the `public_callback` to work in more cases #163
 
 ## [2.3.0] - 2024-03-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Allow to define a custom user management via the `after_logged_in` method #156
+
+### Changed
+- Updated the `public_callback` to work in more cases
+
 ## [2.3.0] - 2024-03-18
 ### Added
 - OIDCAuth allows to authenticate via OIDC

--- a/dash_auth/public_routes.py
+++ b/dash_auth/public_routes.py
@@ -1,9 +1,8 @@
-import inspect
+import logging
 import os
 
-from dash import Dash, callback
-from dash._callback import GLOBAL_CALLBACK_MAP
-from dash import get_app
+from dash import Dash, Input, Output, callback, get_app
+from dash._utils import create_callback_id
 from werkzeug.routing import Map, MapAdapter, Rule
 
 
@@ -70,12 +69,10 @@ def public_callback(*callback_args, **callback_kwargs):
     def decorator(func):
 
         wrapped_func = callback(*callback_args, **callback_kwargs)(func)
-        callback_id = next(
-            (
-                k for k, v in GLOBAL_CALLBACK_MAP.items()
-                if inspect.getsource(v["callback"]) == inspect.getsource(func)
-            ),
-            None,
+        all_args = [*callback_args, *callback_kwargs.values()]
+        callback_id = create_callback_id(
+            [x for x in all_args if isinstance(x, Output)],
+            [x for x in all_args if isinstance(x, Input)],
         )
         try:
             app = get_app()
@@ -83,7 +80,7 @@ def public_callback(*callback_args, **callback_kwargs):
                 get_public_callbacks(app) + [callback_id]
             )
         except Exception:
-            print(
+            logging.info(
                 "Could not set up the public callback as the Dash object "
                 "has not yet been instantiated."
             )


### PR DESCRIPTION
The current public_callback decorator wasn't working well in some cases, including when using dash-extension's DashProxy.

This PR leverages Dash's internal `create_callback_id` to retrieve the callback id to be marked as public.

Also copied test updated from #162 as this PR supersedes the fix in there.